### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag roechi/aws-java-cdk-github-actions:${{ github.event.release.tag_name }}
 
-    - uses: elgohr/Publish-Docker-Github-Action@master
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       name: Publish to Registry
       with:
         name: roechi/aws-java-cdk-github-actions:${{ github.event.release.tag_name }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore